### PR TITLE
CBP-58264 Fix payload corruption in jenkins-run-job@v2 with multi-key JSON parameters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
       run: |
         set -x
         cd /app
-        # Strip newlines that YAML block scalar inputs append to parameters value
+        # Strip newlines that YAML block scalar inputs append to the parameter value
         { set +x; } 2>/dev/null
         IFS=$(printf '\n_'); IFS="${IFS%_}"
         set -f

--- a/action.yml
+++ b/action.yml
@@ -50,4 +50,14 @@ runs:
       run: |
         set -x
         cd /app
-        ./jenkins_actions_app invoke -b $CONFIG_JSON
+        # Strip newlines that YAML block scalar inputs append to parameters value
+        { set +x; } 2>/dev/null
+        IFS=$(printf '\n_'); IFS="${IFS%_}"
+        set -f
+        set -- $CONFIG_JSON
+        unset IFS
+        set +f
+        _cfg=''
+        for _p do _cfg="${_cfg}${_p}"; done
+        set -x
+        ./jenkins_actions_app invoke -b "$_cfg"


### PR DESCRIPTION
This pull request updates the way the `CONFIG_JSON` input is handled in the `action.yml` file to ensure that any newlines appended by YAML block scalar inputs are stripped before passing the configuration to the `jenkins_actions_app`. This prevents issues caused by unintended newlines in the input.

Input handling improvements:

* Modified the script in the `runs:` section of `action.yml` to strip newlines from the `CONFIG_JSON` parameter before invoking the `jenkins_actions_app`, ensuring cleaner and more reliable input handling.

**Why not tr -d '\n'**: tr is not available in the jenkins-actions container — confirmed from CI logs (sh: tr: not found). The fix uses only POSIX sh builtins and printf, both of which are present.